### PR TITLE
add simple config merging

### DIFF
--- a/pkg/operator/merge.go
+++ b/pkg/operator/merge.go
@@ -1,0 +1,91 @@
+package operator
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func mergeProcessConfig(defaultConfigYAML, userConfigYAML []byte, specialCases map[string]mergeFunc) ([]byte, error) {
+	defaultConfigJSON, err := kyaml.ToJSON(defaultConfigYAML)
+	if err != nil {
+		return nil, err
+	}
+	defaultConfigObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, defaultConfigJSON)
+	if err != nil {
+		return nil, err
+	}
+	defaultConfig := defaultConfigObj.(*unstructured.Unstructured)
+
+	if len(userConfigYAML) > 0 {
+		userConfigJSON, err := kyaml.ToJSON(userConfigYAML)
+		if err != nil {
+			glog.Warning(err)
+			// maybe it's just yaml
+			userConfigJSON = userConfigYAML
+		}
+		userConfigObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, userConfigJSON)
+		if err != nil {
+			return nil, err
+		}
+		userConfig := userConfigObj.(*unstructured.Unstructured)
+		if err := mergeConfig(defaultConfig.Object, userConfig.Object, "", specialCases); err != nil {
+			return nil, err
+		}
+	}
+
+	configBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, defaultConfig)
+	if err != nil {
+		return nil, err
+	}
+	return configBytes, nil
+}
+
+type mergeFunc func(dst, src interface{}, currentPath string) (interface{}, error)
+
+// mergeConfig overwrites entries in curr by additional.  It modifies curr.
+func mergeConfig(curr, additional map[string]interface{}, currentPath string, specialCases map[string]mergeFunc) error {
+	for additionalKey, additionalVal := range additional {
+		fullKey := currentPath + "." + additionalKey
+		specialCase, ok := specialCases[fullKey]
+		if ok {
+			var err error
+			curr[additionalKey], err = specialCase(curr[additionalKey], additionalVal, currentPath)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		currVal, ok := curr[additionalKey]
+		if !ok {
+			curr[additionalKey] = additionalVal
+			continue
+		}
+
+		// only some scalars are accepted
+		switch castVal := additionalVal.(type) {
+		case map[string]interface{}:
+			currValAsMap, ok := currVal.(map[string]interface{})
+			if !ok {
+				currValAsMap = map[string]interface{}{}
+				curr[additionalKey] = currValAsMap
+			}
+
+			err := mergeConfig(currValAsMap, castVal, fullKey, specialCases)
+			if err != nil {
+				return err
+			}
+			continue
+
+		default:
+			if err := unstructured.SetNestedField(curr, castVal, additionalKey); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/operator/merge_test.go
+++ b/pkg/operator/merge_test.go
@@ -1,0 +1,122 @@
+package operator
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestMergeConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		curr         map[string]interface{}
+		additional   map[string]interface{}
+		specialCases map[string]mergeFunc
+
+		expected    map[string]interface{}
+		expectedErr string
+	}{
+		{
+			name: "add non-conflicting",
+			curr: map[string]interface{}{
+				"alpha": "first",
+				"bravo": map[string]interface{}{
+					"apple": "one",
+				},
+			},
+			additional: map[string]interface{}{
+				"bravo": map[string]interface{}{
+					"banana": "two",
+					"cake": map[string]interface{}{
+						"armadillo": "uno",
+					},
+				},
+				"charlie": "third",
+			},
+
+			expected: map[string]interface{}{
+				"alpha": "first",
+				"bravo": map[string]interface{}{
+					"apple":  "one",
+					"banana": "two",
+					"cake": map[string]interface{}{
+						"armadillo": "uno",
+					},
+				},
+				"charlie": "third",
+			},
+		},
+		{
+			name: "add conflicting, replace type",
+			curr: map[string]interface{}{
+				"alpha": "first",
+				"bravo": map[string]interface{}{
+					"apple": "one",
+				},
+			},
+			additional: map[string]interface{}{
+				"bravo": map[string]interface{}{
+					"apple": map[string]interface{}{
+						"armadillo": "uno",
+					},
+				},
+			},
+
+			expected: map[string]interface{}{
+				"alpha": "first",
+				"bravo": map[string]interface{}{
+					"apple": map[string]interface{}{
+						"armadillo": "uno",
+					},
+				},
+			},
+		},
+		{
+			name: "nil out",
+			curr: map[string]interface{}{
+				"alpha": "first",
+			},
+			additional: map[string]interface{}{
+				"alpha": nil,
+			},
+
+			expected: map[string]interface{}{
+				"alpha": nil,
+			},
+		},
+		{
+			name: "force empty",
+			curr: map[string]interface{}{
+				"alpha": "first",
+			},
+			additional: map[string]interface{}{
+				"alpha": "",
+			},
+
+			expected: map[string]interface{}{
+				"alpha": "",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := mergeConfig(test.curr, test.additional, "", test.specialCases)
+			switch {
+			case err == nil && len(test.expectedErr) == 0:
+			case err == nil && len(test.expectedErr) != 0:
+				t.Fatalf("missing %q", test.expectedErr)
+			case err != nil && len(test.expectedErr) == 0:
+				t.Fatal(err)
+			case err != nil && len(test.expectedErr) != 0 && !strings.Contains(err.Error(), test.expectedErr):
+				t.Fatalf("expected %q, got %q", test.expectedErr, err)
+			}
+
+			if !reflect.DeepEqual(test.expected, test.curr) {
+				t.Error(diff.ObjectDiff(test.expected, test.curr))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds simple config merging based on bare maps with list of special-case functions for particular keys (and their descendants.  I think it's the simplest possible thing that works while preserving the ability to handle things like like our admission config.

@mfojtik @sttts @liggitt 