### PR TITLE
[WIP] Add ConfigMap injection controller

### DIFF
--- a/cmd/service-serving-cert-signer/main.go
+++ b/cmd/service-serving-cert-signer/main.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apiserver/pkg/util/logs"
 
 	"github.com/openshift/service-serving-cert-signer/pkg/cmd/apiservicecabundle"
+	"github.com/openshift/service-serving-cert-signer/pkg/cmd/configmapcabundle"
 	"github.com/openshift/service-serving-cert-signer/pkg/cmd/operator"
 	"github.com/openshift/service-serving-cert-signer/pkg/cmd/servingcertsigner"
 )
@@ -47,6 +48,7 @@ func NewSSCSCommand() *cobra.Command {
 	cmd.AddCommand(operator.NewOperator())
 	cmd.AddCommand(servingcertsigner.NewController())
 	cmd.AddCommand(apiservicecabundle.NewController())
+	cmd.AddCommand(configmapcabundle.NewController())
 
 	return cmd
 }

--- a/manifests/v3.10.0/configmap-cabundle-controller/clusterrole.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:controller:configmap-cabundle-injector
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update

--- a/manifests/v3.10.0/configmap-cabundle-controller/clusterrolebinding.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/clusterrolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:controller:configmap-cabundle-injector
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:controller:configmap-cabundle-injector
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector-sa

--- a/manifests/v3.10.0/configmap-cabundle-controller/cm.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector-config
+data:
+  controller-config.yaml:

--- a/manifests/v3.10.0/configmap-cabundle-controller/defaultconfig.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/defaultconfig.yaml
@@ -1,0 +1,3 @@
+apiVersion: servicecertsigner.config.openshift.io/v1alpha1
+kind: ConfigMapCABundleInjectorConfig
+caBundleFile: /var/run/configmaps/signing-cabundle/cabundle.crt

--- a/manifests/v3.10.0/configmap-cabundle-controller/deployment.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector
+  labels:
+    app: openshift-configmap-cabundle-injector
+    configmap-cabundle-injector: "true"
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openshift-configmap-cabundle-injector
+      configmap-cabundle-injector: "true"
+  template:
+    metadata:
+      name: configmap-cabundle-injector
+      labels:
+        app: openshift-configmap-cabundle-injector
+        configmap-cabundle-injector: "true"
+    spec:
+      serviceAccountName: configmap-cabundle-injector-sa
+      containers:
+      - name: configmap-cabundle-injector-controller
+        image: ${IMAGE}
+        imagePullPolicy: IfNotPresent
+        command: ["service-serving-cert-signer", "configmap-cabundle-injector"]
+        args:
+        - "--config=/var/run/configmaps/config/controller-config.yaml"
+        ports:
+        - containerPort: 8443
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+        - mountPath: /var/run/configmaps/signing-cabundle
+          name: signing-cabundle
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: configmap-cabundle-injector-serving-cert
+          optional: true
+      - name: signing-cabundle
+        configMap:
+          name: signing-cabundle
+      - name: config
+        configMap:
+          name: configmap-cabundle-injector-config
+
+
+

--- a/manifests/v3.10.0/configmap-cabundle-controller/ns.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-service-cert-signer
+  labels:
+    openshift.io/run-level: "1"

--- a/manifests/v3.10.0/configmap-cabundle-controller/sa.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector-sa

--- a/manifests/v3.10.0/configmap-cabundle-controller/signing-cabundle.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/signing-cabundle.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-service-cert-signer
+  name: signing-cabundle
+data:
+  cabundle.crt:

--- a/manifests/v3.10.0/configmap-cabundle-controller/svc.yaml
+++ b/manifests/v3.10.0/configmap-cabundle-controller/svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: openshift-service-cert-signer
+  name: service-serving-cert-signer
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: service-serving-cert-signer-serving-cert
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: https
+spec:
+  selector:
+    service-serving-cert-signer: "true"
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8443

--- a/pkg/cmd/configmapcabundle/cmd.go
+++ b/pkg/cmd/configmapcabundle/cmd.go
@@ -1,0 +1,89 @@
+package configmapcabundle
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/util/logs"
+
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	servicecertsignerv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/serviceability"
+	"github.com/openshift/service-serving-cert-signer/pkg/controller/configmapcainjector"
+	"github.com/openshift/service-serving-cert-signer/pkg/version"
+)
+
+var (
+	componentName = "openshift-service-serving-cert-signer"
+	configScheme  = runtime.NewScheme()
+)
+
+func init() {
+	if err := operatorv1alpha1.AddToScheme(configScheme); err != nil {
+		panic(err)
+	}
+	if err := servicecertsignerv1alpha1.AddToScheme(configScheme); err != nil {
+		panic(err)
+	}
+}
+
+type ControllerCommandOptions struct {
+	basicFlags *controllercmd.ControllerFlags
+}
+
+func NewController() *cobra.Command {
+	o := &ControllerCommandOptions{
+		basicFlags: controllercmd.NewControllerFlags(),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "configmap-cabundle-injector",
+		Short: "Start the ConfigMap CA Bundle Injection controller",
+		Run: func(cmd *cobra.Command, args []string) {
+			// boiler plate for the "normal" command
+			rand.Seed(time.Now().UTC().UnixNano())
+			logs.InitLogs()
+			defer logs.FlushLogs()
+			defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), version.Get())()
+			defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+			serviceability.StartProfiler()
+
+			if err := o.basicFlags.Validate(); err != nil {
+				glog.Fatal(err)
+			}
+
+			if err := o.StartController(); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+	o.basicFlags.AddFlags(cmd)
+
+	return cmd
+}
+
+// StartController runs the controller
+func (o *ControllerCommandOptions) StartController() error {
+	uncastConfig, err := o.basicFlags.ToConfigObj(configScheme, servicecertsignerv1alpha1.SchemeGroupVersion)
+	if err != nil {
+		return err
+	}
+	// TODO this and how you get the leader election and serving info are the only unique things here
+	config, ok := uncastConfig.(*servicecertsignerv1alpha1.ConfigMapCABundleInjectorConfig)
+	if !ok {
+		return fmt.Errorf("unexpected config: %T", uncastConfig)
+	}
+
+	return controllercmd.NewController(componentName, (&configmapcainjector.ConfigMapCABundleInjectorOptions{Config: config}).RunConfigMapCABundleInjector).
+		WithKubeConfigFile(o.basicFlags.KubeConfigFile, nil).
+		// TODO we can update the API with leader election
+		//WithLeaderElection(config.LeaderElection, "", componentName+"-lock").
+		Run()
+}

--- a/pkg/controller/configmapcainjector/configmap_injecting_controller.go
+++ b/pkg/controller/configmapcainjector/configmap_injecting_controller.go
@@ -1,0 +1,180 @@
+package configmapcainjector
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	informers "k8s.io/client-go/informers/core/v1"
+	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	InjectCABundleAnnotation = "service.alpha.openshift.io/inject-cabundle"
+	InjectionDataKey         = "service-ca.crt"
+)
+
+// ConfigMapCABundleInjectionController is responsible for injecting a CA bundle into configMaps annotated with
+// "service.alpha.openshift.io/inject-cabundle"
+type ConfigMapCABundleInjectionController struct {
+	configMapClient kcoreclient.ConfigMapsGetter
+
+	// configMaps that need to be checked
+	queue workqueue.RateLimitingInterface
+
+	configMapLister    listers.ConfigMapLister
+	configMapHasSynced cache.InformerSynced
+
+	ca string
+
+	// syncHandler does the work. It's factored out for unit testing
+	syncHandler func(serviceKey string) error
+}
+
+// NewConfigMapCABundleInjectionController creates a new ServiceServingCertUpdateController.
+// TODO this should accept a shared informer
+func NewConfigMapCABundleInjectionController(configMaps informers.ConfigMapInformer, configMapsClient kcoreclient.ConfigMapsGetter, ca []byte, resyncInterval time.Duration) *ConfigMapCABundleInjectionController {
+	ic := &ConfigMapCABundleInjectionController{
+		queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		ca:    string(ca),
+	}
+
+	ic.configMapLister = configMaps.Lister()
+	configMaps.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    ic.addConfigMap,
+			UpdateFunc: ic.updateConfigMap,
+		},
+		resyncInterval,
+	)
+	ic.configMapHasSynced = configMaps.Informer().HasSynced
+	ic.configMapClient = configMapsClient
+	ic.syncHandler = ic.syncConfigMap
+
+	return ic
+}
+
+// Run begins watching and syncing.
+func (ic *ConfigMapCABundleInjectionController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer ic.queue.ShutDown()
+
+	// Wait for the stores to fill
+	if !cache.WaitForCacheSync(stopCh, ic.configMapHasSynced) {
+		return
+	}
+
+	glog.V(1).Infof("Starting workers")
+	for i := 0; i < workers; i++ {
+		go wait.Until(ic.runWorker, time.Second, stopCh)
+	}
+	<-stopCh
+	glog.V(1).Infof("Shutting down")
+}
+
+func (ic *ConfigMapCABundleInjectionController) enqueueConfigMap(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		return
+	}
+
+	ic.queue.Add(key)
+}
+
+func (ic *ConfigMapCABundleInjectionController) addConfigMap(obj interface{}) {
+	cm, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		// We should only ever get configMaps from the event handler.
+		glog.V(2).Infof("added object not configMap type: %T", obj)
+		return
+	}
+
+	if !hasCABundleAnnotation(cm) {
+		return
+	}
+
+	glog.V(4).Infof("adding %s", cm.Name)
+	ic.enqueueConfigMap(cm)
+}
+
+func (ic *ConfigMapCABundleInjectionController) updateConfigMap(old, cur interface{}) {
+	cm, ok := cur.(*v1.ConfigMap)
+	if !ok {
+		// We should only ever get configMaps from the event handler.
+		glog.V(2).Infof("updated object not configMap type: %T", cur)
+		return
+	}
+
+	if !hasCABundleAnnotation(cm) {
+		return
+	}
+
+	glog.V(4).Infof("updating %s", cm.Name)
+	ic.enqueueConfigMap(cm)
+}
+
+func (ic *ConfigMapCABundleInjectionController) runWorker() {
+	for ic.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem deals with one key off the queue.  It returns false when it's time to quit.
+func (ic *ConfigMapCABundleInjectionController) processNextWorkItem() bool {
+	key, quit := ic.queue.Get()
+	if quit {
+		return false
+	}
+	defer ic.queue.Done(key)
+
+	err := ic.syncHandler(key.(string))
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+		ic.queue.AddRateLimited(key)
+		return true
+	}
+
+	ic.queue.Forget(key)
+	return true
+}
+
+// syncSecret will sync the configMap with the CA.
+// This function is not meant to be invoked concurrently with the same key.
+func (ic *ConfigMapCABundleInjectionController) syncConfigMap(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	sharedConfigMap, err := ic.configMapLister.ConfigMaps(namespace).Get(name)
+	if kapierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// skip updating when the CA bundle is already there
+	if data, ok := sharedConfigMap.Data[InjectionDataKey]; ok && data == ic.ca {
+		return nil
+	}
+
+	configMapCopy := sharedConfigMap.DeepCopy()
+	// make a copy to avoid mutating cache state
+	configMapCopy.Data[InjectionDataKey] = ic.ca
+
+	_, err = ic.configMapClient.ConfigMaps(configMapCopy.Namespace).Update(configMapCopy)
+	return err
+}
+
+func hasCABundleAnnotation(cm *v1.ConfigMap) bool {
+	return strings.ToLower(strings.TrimSpace(cm.Annotations[InjectCABundleAnnotation])) == "true"
+}

--- a/pkg/controller/configmapcainjector/configmap_injecting_controller_test.go
+++ b/pkg/controller/configmapcainjector/configmap_injecting_controller_test.go
@@ -1,0 +1,135 @@
+package configmapcainjector
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	listers "k8s.io/client-go/listers/core/v1"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestSyncConfigMapCABundle(t *testing.T) {
+	tests := []struct {
+		name               string
+		startingConfigMaps []runtime.Object
+		key                string
+		caBundle           []byte
+		validateActions    func(t *testing.T, actions []clienttesting.Action)
+	}{
+		{
+			name:     "missing",
+			key:      "foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "requested and empty",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{InjectCABundleAnnotation: "true"},
+						Namespace: "foo",
+					},
+					Data: map[string]string{},
+				},
+			},
+			key:      "foo/foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "configmaps") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
+				if expected := "content"; string(actual.Data[InjectionDataKey]) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "requested and different",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{InjectCABundleAnnotation: "true"},
+						Namespace: "foo",
+					},
+					Data: map[string]string{
+						InjectionDataKey: "foo",
+					},
+				},
+			},
+			key:      "foo/foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "configmaps") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
+				if expected := "content"; string(actual.Data[InjectionDataKey]) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "requested and same",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{InjectCABundleAnnotation: "true"},
+						Namespace: "foo",
+					},
+					Data: map[string]string{
+						InjectionDataKey: "content",
+					},
+				},
+			},
+			key:      "foo/foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tc.startingConfigMaps...)
+			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, configMap := range tc.startingConfigMaps {
+				index.Add(configMap)
+			}
+			c := &ConfigMapCABundleInjectionController{
+				configMapLister: listers.NewConfigMapLister(index),
+				configMapClient: fakeClient.CoreV1(),
+				ca:              tc.caBundle,
+			}
+			err := c.syncConfigMap(tc.key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.validateActions(t, fakeClient.Actions())
+		})
+	}
+}

--- a/pkg/controller/configmapcainjector/starter.go
+++ b/pkg/controller/configmapcainjector/starter.go
@@ -1,0 +1,65 @@
+package configmapcainjector
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	servicecertsignerv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
+	"k8s.io/client-go/informers"
+)
+
+type ConfigMapCABundleInjectorOptions struct {
+	Config *servicecertsignerv1alpha1.ConfigMapCABundleInjectorConfig
+}
+
+// These might need adjustment
+const (
+	InformerResyncInterval = 2 * time.Minute
+	ControllerResyncInterval = 20 * time.Minute
+)
+
+func (o *ConfigMapCABundleInjectorOptions) RunConfigMapCABundleInjector(clientConfig *rest.Config, stopCh <-chan struct{}) error {
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+	kubeInformers := informers.NewSharedInformerFactory(kubeClient, InformerResyncInterval)
+
+	caPem, err := ioutil.ReadFile(o.Config.CABundleFile)
+	if err != nil {
+		return err
+	}
+
+	// Verify that there is at least one cert in the bundle file
+	block, _ := pem.Decode(caPem)
+	if block == nil {
+		return fmt.Errorf("failed to parse CA bundle file as pem")
+	}
+	if _, err = x509.ParseCertificate(block.Bytes); err != nil {
+		return err
+	}
+	glog.V(4).Infof("using ca PEM: %s", string(caPem))
+
+	configMapInjectorController := NewConfigMapCABundleInjectionController(
+		kubeInformers.Core().V1().ConfigMaps(),
+		kubeClient.CoreV1(),
+		caPem,
+		ControllerResyncInterval,
+	)
+
+	kubeInformers.Start(stopCh)
+
+	go configMapInjectorController.Run(1, stopCh)
+
+	<-stopCh
+
+	return fmt.Errorf("stopped")
+}

--- a/pkg/operator/sync_all_v311_00.go
+++ b/pkg/operator/sync_all_v311_00.go
@@ -10,20 +10,23 @@ import (
 func sync_v311_00_to_latest(c ServiceCertSignerOperator, operatorConfig *scsv1alpha1.ServiceCertSignerOperatorConfig, previousAvailability *operatorsv1alpha1.VersionAvailablity) (operatorsv1alpha1.VersionAvailablity, []error) {
 	signingVersionAvailability, signingErrors := syncSigningController_v311_00_to_latest(c, operatorConfig, previousAvailability)
 	apiServiceInjectorVersionAvailability, apiServiceInjectorErrors := syncAPIServiceController_v311_00_to_latest(c, operatorConfig, previousAvailability)
+	configMapCABundleInjectorVersionAvailability, configMapCABundleInjectorErrors := syncConfigMapCABundleController_v311_00_to_latest(c, operatorConfig, previousAvailability)
 
 	allErrors := []error{}
 	allErrors = append(allErrors, signingErrors...)
 	allErrors = append(allErrors, apiServiceInjectorErrors...)
+	allErrors = append(allErrors, configMapCABundleInjectorErrors...)
 
 	mergedVersionAvailability := operatorsv1alpha1.VersionAvailablity{
 		Version: operatorConfig.Spec.Version,
 	}
 	mergedVersionAvailability.Generations = append(mergedVersionAvailability.Generations, signingVersionAvailability.Generations...)
 	mergedVersionAvailability.Generations = append(mergedVersionAvailability.Generations, apiServiceInjectorVersionAvailability.Generations...)
-	if signingVersionAvailability.UpdatedReplicas > 0 && apiServiceInjectorVersionAvailability.UpdatedReplicas > 0 {
+	mergedVersionAvailability.Generations = append(mergedVersionAvailability.Generations, configMapCABundleInjectorVersionAvailability.Generations...)
+	if signingVersionAvailability.UpdatedReplicas > 0 && apiServiceInjectorVersionAvailability.UpdatedReplicas > 0 && configMapCABundleInjectorVersionAvailability.UpdatedReplicas > 0 {
 		mergedVersionAvailability.UpdatedReplicas = 1
 	}
-	if signingVersionAvailability.ReadyReplicas > 0 && apiServiceInjectorVersionAvailability.ReadyReplicas > 0 {
+	if signingVersionAvailability.ReadyReplicas > 0 && apiServiceInjectorVersionAvailability.ReadyReplicas > 0 && configMapCABundleInjectorVersionAvailability.ReadyReplicas > 0 {
 		mergedVersionAvailability.ReadyReplicas = 1
 	}
 	for _, err := range allErrors {

--- a/pkg/operator/sync_configmapcabundle_v311_00.go
+++ b/pkg/operator/sync_configmapcabundle_v311_00.go
@@ -1,0 +1,130 @@
+package operator
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	scsv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcecread"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/service-serving-cert-signer/pkg/operator/v310_00_assets"
+)
+
+// syncConfigMapCABundleController_v311_00_to_latest takes care of synchronizing (not upgrading) the thing we're managing.
+// most of the time the sync method will be good for a large span of minor versions
+func syncConfigMapCABundleController_v311_00_to_latest(c ServiceCertSignerOperator, operatorConfig *scsv1alpha1.ServiceCertSignerOperatorConfig, previousAvailability *operatorsv1alpha1.VersionAvailablity) (operatorsv1alpha1.VersionAvailablity, []error) {
+	versionAvailability := operatorsv1alpha1.VersionAvailablity{
+		Version: operatorConfig.Spec.Version,
+	}
+
+	errors := []error{}
+	var err error
+
+	requiredNamespace := resourceread.ReadNamespaceV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/ns.yaml"))
+	if _, _, err = resourceapply.ApplyNamespace(c.corev1Client, requiredNamespace); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "ns", err))
+	}
+
+	requiredClusterRole := resourceread.ReadClusterRoleV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/clusterrole.yaml"))
+	if _, _, err = resourceapply.ApplyClusterRole(c.rbacv1Client, requiredClusterRole); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "svc", err))
+	}
+
+	requiredClusterRoleBinding := resourceread.ReadClusterRoleBindingV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/clusterrolebinding.yaml"))
+	if _, _, err = resourceapply.ApplyClusterRoleBinding(c.rbacv1Client, requiredClusterRoleBinding); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "svc", err))
+	}
+
+	requiredService := resourceread.ReadServiceV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/svc.yaml"))
+	if _, _, err = resourceapply.ApplyService(c.corev1Client, requiredService); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "svc", err))
+	}
+
+	requiredSA := resourceread.ReadServiceAccountV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/sa.yaml"))
+	_, saModified, err := resourceapply.ApplyServiceAccount(c.corev1Client, requiredSA)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "sa", err))
+	}
+
+	// TODO create a new configmap whenever the data value changes
+	_, configMapModified, err := manageConfigMapCABundleConfigMap_v311_00_to_latest(c.corev1Client, operatorConfig)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap", err))
+	}
+
+	_, signingCABundleModified, err := manageConfigMapCABundle(c.corev1Client)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "signing-key", err))
+	}
+
+	forceDeployment := operatorConfig.ObjectMeta.Generation != operatorConfig.Status.ObservedGeneration
+	if saModified { // SA modification can cause new tokens
+		forceDeployment = true
+	}
+	if signingCABundleModified {
+		forceDeployment = true
+	}
+	if configMapModified {
+		forceDeployment = true
+	}
+
+	// we have attempted to update our configmaps and secrets, now it is time to create the DS
+	// TODO check basic preconditions here
+	actualDeployment, _, err := manageConfigMapCABundleDeployment_v311_00_to_latest(c.appsv1Client, operatorConfig, previousAvailability, forceDeployment)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "deployment", err))
+	}
+
+	return resourcemerge.ApplyGenerationAvailability(versionAvailability, actualDeployment, errors...), errors
+}
+
+func manageConfigMapCABundleConfigMap_v311_00_to_latest(client coreclientv1.ConfigMapsGetter, operatorConfig *scsv1alpha1.ServiceCertSignerOperatorConfig) (*corev1.ConfigMap, bool, error) {
+	configMap := resourceread.ReadConfigMapV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/cm.yaml"))
+	defaultConfig := v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/defaultconfig.yaml")
+	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "controller-config.yaml", nil, defaultConfig, operatorConfig.Spec.ConfigMapCABundleInjectorConfig.Raw)
+	if err != nil {
+		return nil, false, err
+	}
+	return resourceapply.ApplyConfigMap(client, requiredConfigMap)
+}
+
+func manageConfigMapCABundleDeployment_v311_00_to_latest(client appsclientv1.DeploymentsGetter, options *scsv1alpha1.ServiceCertSignerOperatorConfig, previousAvailability *operatorsv1alpha1.VersionAvailablity, forceDeployment bool) (*appsv1.Deployment, bool, error) {
+	required := resourceread.ReadDeploymentV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/deployment.yaml"))
+	required.Spec.Template.Spec.Containers[0].Image = options.Spec.ImagePullSpec
+	required.Spec.Template.Spec.Containers[0].Args = append(required.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", options.Spec.Logging.Level))
+
+	return resourceapply.ApplyDeployment(client, required, resourcemerge.ExpectedDeploymentGeneration(required, previousAvailability), forceDeployment)
+}
+
+// TODO manage rotation in addition to initial creation
+func manageConfigMapCABundle(client coreclientv1.CoreV1Interface) (*corev1.ConfigMap, bool, error) {
+	configMap := resourceread.ReadConfigMapV1OrDie(v310_00_assets.MustAsset("v3.10.0/configmap-cabundle-controller/signing-cabundle.yaml"))
+	existing, err := client.ConfigMaps(configMap.Namespace).Get(configMap.Name, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		return existing, false, err
+	}
+
+	secret := resourceread.ReadSecretV1OrDie(v310_00_assets.MustAsset("v3.10.0/service-serving-cert-signer-controller/signing-secret.yaml"))
+	currentSigningKeySecret, err := client.Secrets(secret.Namespace).Get(secret.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return existing, false, err
+	}
+	if err != nil {
+		return existing, false, err
+	}
+	if len(currentSigningKeySecret.Data["tls.crt"]) == 0 {
+		return existing, false, err
+	}
+
+	configMap.Data["cabundle.crt"] = string(currentSigningKeySecret.Data["tls.crt"])
+
+	return resourceapply.ApplyConfigMap(client, configMap)
+}

--- a/pkg/operator/v310_00_assets/bindata.go
+++ b/pkg/operator/v310_00_assets/bindata.go
@@ -9,6 +9,15 @@
 // manifests/v3.10.0/apiservice-cabundle-controller/sa.yaml
 // manifests/v3.10.0/apiservice-cabundle-controller/signing-cabundle.yaml
 // manifests/v3.10.0/apiservice-cabundle-controller/svc.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/clusterrole.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/clusterrolebinding.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/cm.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/defaultconfig.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/deployment.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/ns.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/sa.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/signing-cabundle.yaml
+// manifests/v3.10.0/configmap-cabundle-controller/svc.yaml
 // manifests/v3.10.0/service-serving-cert-signer-controller/clusterrole.yaml
 // manifests/v3.10.0/service-serving-cert-signer-controller/clusterrolebinding.yaml
 // manifests/v3.10.0/service-serving-cert-signer-controller/cm.yaml
@@ -332,6 +341,281 @@ func v3100ApiserviceCabundleControllerSvcYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "v3.10.0/apiservice-cabundle-controller/svc.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerClusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:controller:configmap-cabundle-injector
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+`)
+
+func v3100ConfigmapCabundleControllerClusterroleYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerClusterroleYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerClusterroleYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerClusterroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/clusterrole.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerClusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:controller:configmap-cabundle-injector
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:controller:configmap-cabundle-injector
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector-sa
+`)
+
+func v3100ConfigmapCabundleControllerClusterrolebindingYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerClusterrolebindingYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerClusterrolebindingYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerClusterrolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/clusterrolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerCmYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector-config
+data:
+  controller-config.yaml:
+`)
+
+func v3100ConfigmapCabundleControllerCmYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerCmYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerCmYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerCmYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerDefaultconfigYaml = []byte(`apiVersion: servicecertsigner.config.openshift.io/v1alpha1
+kind: ConfigMapCABundleInjectorConfig
+caBundleFile: /var/run/configmaps/signing-cabundle/cabundle.crt
+`)
+
+func v3100ConfigmapCabundleControllerDefaultconfigYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerDefaultconfigYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerDefaultconfigYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerDefaultconfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/defaultconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerDeploymentYaml = []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector
+  labels:
+    app: openshift-configmap-cabundle-injector
+    configmap-cabundle-injector: "true"
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openshift-configmap-cabundle-injector
+      configmap-cabundle-injector: "true"
+  template:
+    metadata:
+      name: configmap-cabundle-injector
+      labels:
+        app: openshift-configmap-cabundle-injector
+        configmap-cabundle-injector: "true"
+    spec:
+      serviceAccountName: configmap-cabundle-injector-sa
+      containers:
+      - name: configmap-cabundle-injector-controller
+        image: ${IMAGE}
+        imagePullPolicy: IfNotPresent
+        command: ["service-serving-cert-signer", "configmap-cabundle-injector"]
+        args:
+        - "--config=/var/run/configmaps/config/controller-config.yaml"
+        ports:
+        - containerPort: 8443
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+        - mountPath: /var/run/configmaps/signing-cabundle
+          name: signing-cabundle
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: configmap-cabundle-injector-serving-cert
+          optional: true
+      - name: signing-cabundle
+        configMap:
+          name: signing-cabundle
+      - name: config
+        configMap:
+          name: configmap-cabundle-injector-config
+
+
+
+`)
+
+func v3100ConfigmapCabundleControllerDeploymentYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerDeploymentYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerDeploymentYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerNsYaml = []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-service-cert-signer
+  labels:
+    openshift.io/run-level: "1"
+`)
+
+func v3100ConfigmapCabundleControllerNsYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerNsYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerNsYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerNsYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/ns.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerSaYaml = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: openshift-service-cert-signer
+  name: configmap-cabundle-injector-sa
+`)
+
+func v3100ConfigmapCabundleControllerSaYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerSaYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerSaYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerSaYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/sa.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerSigningCabundleYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-service-cert-signer
+  name: signing-cabundle
+data:
+  cabundle.crt:
+`)
+
+func v3100ConfigmapCabundleControllerSigningCabundleYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerSigningCabundleYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerSigningCabundleYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerSigningCabundleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/signing-cabundle.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3100ConfigmapCabundleControllerSvcYaml = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  namespace: openshift-service-cert-signer
+  name: service-serving-cert-signer
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: service-serving-cert-signer-serving-cert
+    prometheus.io/scrape: "true"
+    prometheus.io/scheme: https
+spec:
+  selector:
+    service-serving-cert-signer: "true"
+  ports:
+  - name: https
+    port: 443
+    targetPort: 8443
+`)
+
+func v3100ConfigmapCabundleControllerSvcYamlBytes() ([]byte, error) {
+	return _v3100ConfigmapCabundleControllerSvcYaml, nil
+}
+
+func v3100ConfigmapCabundleControllerSvcYaml() (*asset, error) {
+	bytes, err := v3100ConfigmapCabundleControllerSvcYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.10.0/configmap-cabundle-controller/svc.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -689,6 +973,15 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.10.0/apiservice-cabundle-controller/sa.yaml": v3100ApiserviceCabundleControllerSaYaml,
 	"v3.10.0/apiservice-cabundle-controller/signing-cabundle.yaml": v3100ApiserviceCabundleControllerSigningCabundleYaml,
 	"v3.10.0/apiservice-cabundle-controller/svc.yaml": v3100ApiserviceCabundleControllerSvcYaml,
+	"v3.10.0/configmap-cabundle-controller/clusterrole.yaml": v3100ConfigmapCabundleControllerClusterroleYaml,
+	"v3.10.0/configmap-cabundle-controller/clusterrolebinding.yaml": v3100ConfigmapCabundleControllerClusterrolebindingYaml,
+	"v3.10.0/configmap-cabundle-controller/cm.yaml": v3100ConfigmapCabundleControllerCmYaml,
+	"v3.10.0/configmap-cabundle-controller/defaultconfig.yaml": v3100ConfigmapCabundleControllerDefaultconfigYaml,
+	"v3.10.0/configmap-cabundle-controller/deployment.yaml": v3100ConfigmapCabundleControllerDeploymentYaml,
+	"v3.10.0/configmap-cabundle-controller/ns.yaml": v3100ConfigmapCabundleControllerNsYaml,
+	"v3.10.0/configmap-cabundle-controller/sa.yaml": v3100ConfigmapCabundleControllerSaYaml,
+	"v3.10.0/configmap-cabundle-controller/signing-cabundle.yaml": v3100ConfigmapCabundleControllerSigningCabundleYaml,
+	"v3.10.0/configmap-cabundle-controller/svc.yaml": v3100ConfigmapCabundleControllerSvcYaml,
 	"v3.10.0/service-serving-cert-signer-controller/clusterrole.yaml": v3100ServiceServingCertSignerControllerClusterroleYaml,
 	"v3.10.0/service-serving-cert-signer-controller/clusterrolebinding.yaml": v3100ServiceServingCertSignerControllerClusterrolebindingYaml,
 	"v3.10.0/service-serving-cert-signer-controller/cm.yaml": v3100ServiceServingCertSignerControllerCmYaml,
@@ -751,6 +1044,17 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"sa.yaml": &bintree{v3100ApiserviceCabundleControllerSaYaml, map[string]*bintree{}},
 			"signing-cabundle.yaml": &bintree{v3100ApiserviceCabundleControllerSigningCabundleYaml, map[string]*bintree{}},
 			"svc.yaml": &bintree{v3100ApiserviceCabundleControllerSvcYaml, map[string]*bintree{}},
+		}},
+		"configmap-cabundle-controller": &bintree{nil, map[string]*bintree{
+			"clusterrole.yaml": &bintree{v3100ConfigmapCabundleControllerClusterroleYaml, map[string]*bintree{}},
+			"clusterrolebinding.yaml": &bintree{v3100ConfigmapCabundleControllerClusterrolebindingYaml, map[string]*bintree{}},
+			"cm.yaml": &bintree{v3100ConfigmapCabundleControllerCmYaml, map[string]*bintree{}},
+			"defaultconfig.yaml": &bintree{v3100ConfigmapCabundleControllerDefaultconfigYaml, map[string]*bintree{}},
+			"deployment.yaml": &bintree{v3100ConfigmapCabundleControllerDeploymentYaml, map[string]*bintree{}},
+			"ns.yaml": &bintree{v3100ConfigmapCabundleControllerNsYaml, map[string]*bintree{}},
+			"sa.yaml": &bintree{v3100ConfigmapCabundleControllerSaYaml, map[string]*bintree{}},
+			"signing-cabundle.yaml": &bintree{v3100ConfigmapCabundleControllerSigningCabundleYaml, map[string]*bintree{}},
+			"svc.yaml": &bintree{v3100ConfigmapCabundleControllerSvcYaml, map[string]*bintree{}},
 		}},
 		"service-serving-cert-signer-controller": &bintree{nil, map[string]*bintree{
 			"clusterrole.yaml": &bintree{v3100ServiceServingCertSignerControllerClusterroleYaml, map[string]*bintree{}},


### PR DESCRIPTION
This adds a controller managed by the operator that injects the service CA bundle into configmaps that are annotated with service.alpha.openshift.io/inject-cabundle: true. 
The current state of the PR is that the operator starts the controller and it runs, but I have yet to get it to properly update a configmap, so there is something off at the moment. But I would like to go ahead and get some eyes on it.
@openshift/sig-security 