### PR TITLE
Add leader election

### DIFF
--- a/bindata/v3.10.0/apiservice-cabundle-controller/clusterrole.yaml
+++ b/bindata/v3.10.0/apiservice-cabundle-controller/clusterrole.yaml
@@ -13,3 +13,19 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/bindata/v3.10.0/configmap-cabundle-controller/clusterrole.yaml
+++ b/bindata/v3.10.0/configmap-cabundle-controller/clusterrole.yaml
@@ -12,3 +12,19 @@ rules:
   - list
   - watch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/bindata/v3.10.0/service-serving-cert-signer-controller/clusterrole.yaml
+++ b/bindata/v3.10.0/service-serving-cert-signer-controller/clusterrole.yaml
@@ -26,3 +26,19 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/pkg/cmd/configmapcabundle/cmd.go
+++ b/pkg/cmd/configmapcabundle/cmd.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/util/logs"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	servicecertsignerv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -21,8 +22,9 @@ import (
 )
 
 var (
-	componentName = "openshift-service-serving-cert-signer"
-	configScheme  = runtime.NewScheme()
+	componentName      = "openshift-service-serving-cert-signer-cabundle-injector"
+	componentNamespace = "openshift-service-cert-signer"
+	configScheme       = runtime.NewScheme()
 )
 
 func init() {
@@ -81,9 +83,9 @@ func (o *ControllerCommandOptions) StartController() error {
 		return fmt.Errorf("unexpected config: %T", uncastConfig)
 	}
 
-	return controllercmd.NewController(componentName, (&configmapcainjector.ConfigMapCABundleInjectorOptions{Config: config}).RunConfigMapCABundleInjector).
+	opts := &configmapcainjector.ConfigMapCABundleInjectorOptions{Config: config, LeaderElection: configv1.LeaderElection{}}
+	return controllercmd.NewController(componentName, opts.RunConfigMapCABundleInjector).
 		WithKubeConfigFile(o.basicFlags.KubeConfigFile, nil).
-		// TODO we can update the API with leader election
-		//WithLeaderElection(config.LeaderElection, "", componentName+"-lock").
+		WithLeaderElection(opts.LeaderElection, componentNamespace, componentName+"-lock").
 		Run()
 }

--- a/pkg/cmd/servingcertsigner/cmd.go
+++ b/pkg/cmd/servingcertsigner/cmd.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/util/logs"
 
 	"github.com/golang/glog"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	servicecertsignerv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -21,8 +22,9 @@ import (
 )
 
 var (
-	componentName = "openshift-service-serving-cert-signer"
-	configScheme  = runtime.NewScheme()
+	componentName      = "openshift-service-serving-cert-signer-serving-ca"
+	componentNamespace = "openshift-service-cert-signer"
+	configScheme       = runtime.NewScheme()
 )
 
 func init() {
@@ -81,9 +83,9 @@ func (o *ControllerCommandOptions) StartController() error {
 		return fmt.Errorf("unexpected config: %T", uncastConfig)
 	}
 
-	return controllercmd.NewController(componentName, (&servingcert.ServingCertOptions{Config: config}).RunServingCert).
+	opts := &servingcert.ServingCertOptions{Config: config, LeaderElection: configv1.LeaderElection{}}
+	return controllercmd.NewController(componentName, opts.RunServingCert).
 		WithKubeConfigFile(o.basicFlags.KubeConfigFile, nil).
-		// TODO we can update the API with leader election
-		//WithLeaderElection(config.LeaderElection, "", componentName+"-lock").
+		WithLeaderElection(opts.LeaderElection, componentNamespace, componentName+"-lock").
 		Run()
 }

--- a/pkg/controller/apiservicecabundle/starter.go
+++ b/pkg/controller/apiservicecabundle/starter.go
@@ -9,11 +9,13 @@ import (
 	apiserviceclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	apiserviceinformer "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
 
+	configv1 "github.com/openshift/api/config/v1"
 	servicecertsignerv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
 )
 
 type APIServiceCABundleInjectorOptions struct {
-	Config *servicecertsignerv1alpha1.APIServiceCABundleInjectorConfig
+	Config         *servicecertsignerv1alpha1.APIServiceCABundleInjectorConfig
+	LeaderElection configv1.LeaderElection
 }
 
 func (o *APIServiceCABundleInjectorOptions) RunAPIServiceCABundleInjector(clientConfig *rest.Config, stopCh <-chan struct{}) error {

--- a/pkg/controller/configmapcainjector/starter.go
+++ b/pkg/controller/configmapcainjector/starter.go
@@ -1,28 +1,29 @@
 package configmapcainjector
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"time"
 
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"crypto/x509"
-	"encoding/pem"
-	"io/ioutil"
-
 	"github.com/golang/glog"
+	configv1 "github.com/openshift/api/config/v1"
 	servicecertsignerv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
-	"k8s.io/client-go/informers"
 )
 
 type ConfigMapCABundleInjectorOptions struct {
-	Config *servicecertsignerv1alpha1.ConfigMapCABundleInjectorConfig
+	Config         *servicecertsignerv1alpha1.ConfigMapCABundleInjectorConfig
+	LeaderElection configv1.LeaderElection
 }
 
 // These might need adjustment
 const (
-	InformerResyncInterval = 2 * time.Minute
+	InformerResyncInterval   = 2 * time.Minute
 	ControllerResyncInterval = 20 * time.Minute
 )
 

--- a/pkg/controller/servingcert/starter.go
+++ b/pkg/controller/servingcert/starter.go
@@ -4,16 +4,18 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	configv1 "github.com/openshift/api/config/v1"
 	servicecertsignerv1alpha1 "github.com/openshift/api/servicecertsigner/v1alpha1"
 	"github.com/openshift/library-go/pkg/crypto"
-	"k8s.io/client-go/informers"
 )
 
 type ServingCertOptions struct {
-	Config *servicecertsignerv1alpha1.ServiceServingCertSignerConfig
+	Config         *servicecertsignerv1alpha1.ServiceServingCertSignerConfig
+	LeaderElection configv1.LeaderElection
 }
 
 func (o *ServingCertOptions) RunServingCert(clientConfig *rest.Config, stopCh <-chan struct{}) error {

--- a/pkg/operator/v310_00_assets/bindata.go
+++ b/pkg/operator/v310_00_assets/bindata.go
@@ -85,6 +85,22 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 `)
 
 func v3100ApiserviceCabundleControllerClusterroleYamlBytes() ([]byte, error) {
@@ -360,6 +376,22 @@ rules:
   - list
   - watch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 `)
 
 func v3100ConfigmapCabundleControllerClusterroleYamlBytes() ([]byte, error) {
@@ -499,9 +531,10 @@ spec:
       - name: config
         configMap:
           name: configmap-cabundle-injector-config
-
-
-
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - operator: Exists
 `)
 
 func v3100ConfigmapCabundleControllerDeploymentYamlBytes() ([]byte, error) {
@@ -649,6 +682,22 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 `)
 
 func v3100ServiceServingCertSignerControllerClusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Regenerating the bindata here also updates the taints and tolerations for the configmap injector controller, missed by #33 
@openshift/sig-security 