### PR TITLE
Warn when signing CA is halfway expired

### DIFF
--- a/pkg/operator/util/ca_expiry.go
+++ b/pkg/operator/util/ca_expiry.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"crypto/x509"
+	"time"
+)
+
+// CertHalfwayExpired returns true if half of the cert validity period has elapsed, false if not.
+func CertHalfwayExpired(cert *x509.Certificate) bool {
+	now := time.Now()
+	halfValidPeriod := cert.NotAfter.Sub(cert.NotBefore).Nanoseconds() / 2
+	halfExpiration := cert.NotBefore.Add(time.Duration(halfValidPeriod) * time.Nanosecond)
+	return now.After(halfExpiration)
+}

--- a/pkg/operator/util/ca_expiry_test.go
+++ b/pkg/operator/util/ca_expiry_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+)
+
+func TestCertHalfwayExpired(t *testing.T) {
+	tests := map[string]struct {
+		testCert *x509.Certificate
+		expected bool
+	}{
+		"expired now": {
+			testCert: &x509.Certificate{
+				NotBefore: time.Now().AddDate(0, 0, -1),
+				NotAfter:  time.Now(),
+			},
+			expected: true,
+		},
+		"time left": {
+			testCert: &x509.Certificate{
+				NotBefore: time.Now().AddDate(0, 0, -1),
+				NotAfter:  time.Now().AddDate(0, 0, 2),
+			},
+			expected: false,
+		},
+		"time up": {
+			testCert: &x509.Certificate{
+				NotBefore: time.Now().AddDate(0, 0, -2),
+				NotAfter:  time.Now().AddDate(0, 0, 1),
+			},
+			expected: true,
+		},
+	}
+	for name, tc := range tests {
+		if CertHalfwayExpired(tc.testCert) != tc.expected {
+			t.Errorf("%s: unexpected result, expected %v, got %v", name, tc.expected, !tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the check function for half of the CA lifetime (half of its lifetime is for a rollover grace period), and calls it in manageSigningSecret_v311_00_to_latest() to check the existing signing CA. For now, log a warning.
@openshift/sig-auth 