### PR TITLE
Fix crash on nil configMap data

### DIFF
--- a/pkg/controller/configmapcainjector/configmap_injecting_controller.go
+++ b/pkg/controller/configmapcainjector/configmap_injecting_controller.go
@@ -167,8 +167,13 @@ func (ic *ConfigMapCABundleInjectionController) syncConfigMap(key string) error 
 		return nil
 	}
 
-	configMapCopy := sharedConfigMap.DeepCopy()
 	// make a copy to avoid mutating cache state
+	configMapCopy := sharedConfigMap.DeepCopy()
+
+	if configMapCopy.Data == nil {
+		configMapCopy.Data = map[string]string{}
+	}
+
 	configMapCopy.Data[InjectionDataKey] = ic.ca
 
 	_, err = ic.configMapClient.ConfigMaps(configMapCopy.Namespace).Update(configMapCopy)


### PR DESCRIPTION
Creating an annotated configMap without an initial data item will cause a crash. Fix this by initializing configMap.Data if nil.
@openshift/sig-auth 