### PR TITLE
Add legacy SA token bundle injector controller

### DIFF
--- a/bindata/v3.10.0/configmap-cabundle-controller/clusterrole.yaml
+++ b/bindata/v3.10.0/configmap-cabundle-controller/clusterrole.yaml
@@ -28,3 +28,14 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/pkg/controller/configmapcainjector/controller/sa_token_cabundle_controller.go
+++ b/pkg/controller/configmapcainjector/controller/sa_token_cabundle_controller.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	informers "k8s.io/client-go/informers/core/v1"
+	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	listers "k8s.io/client-go/listers/core/v1"
+
+	"bytes"
+
+	"github.com/openshift/service-serving-cert-signer/pkg/boilerplate/controller"
+	"github.com/openshift/service-serving-cert-signer/pkg/controller/api"
+)
+
+// saTokenCABundleInjectionController is responsible for injecting a CA bundle into service account token secrets.
+type saTokenCABundleInjectionController struct {
+	secretsClient kcoreclient.SecretsGetter
+	secretsLister listers.SecretLister
+
+	ca []byte
+}
+
+func secretIsSAToken(obj v1.Object) bool {
+	return obj.(*corev1.Secret).Type == corev1.SecretTypeServiceAccountToken
+}
+
+func NewSATokenCABundleInjectionController(secrets informers.SecretInformer, secretsClient kcoreclient.SecretsGetter, ca string) controller.Runner {
+	tc := &saTokenCABundleInjectionController{
+		secretsClient: secretsClient,
+		secretsLister: secrets.Lister(),
+		ca:            []byte(ca),
+	}
+
+	return controller.New("SATokenCABundleInjectionController", tc,
+		controller.WithInformer(secrets, controller.FilterFuncs{
+			AddFunc: secretIsSAToken,
+			UpdateFunc: func(old, cur v1.Object) bool {
+				return secretIsSAToken(cur)
+			},
+		}),
+	)
+}
+
+func (tc *saTokenCABundleInjectionController) Key(namespace, name string) (v1.Object, error) {
+	return tc.secretsLister.Secrets(namespace).Get(name)
+}
+
+func (tc *saTokenCABundleInjectionController) Sync(obj v1.Object) error {
+	secret := obj.(*corev1.Secret)
+
+	// skip updating when the CA bundle is already there and the same
+	if data, ok := secret.Data[api.InjectionDataKey]; ok && bytes.Equal(data, tc.ca) {
+		return nil
+	}
+
+	// make a copy to avoid mutating cache state
+	secretCopy := secret.DeepCopy()
+
+	if secretCopy.Data == nil {
+		secretCopy.Data = map[string][]byte{}
+	}
+	secretCopy.Data[api.InjectionDataKey] = tc.ca
+
+	_, err := tc.secretsClient.Secrets(secretCopy.Namespace).Update(secretCopy)
+	return err
+}

--- a/pkg/controller/configmapcainjector/controller/sa_token_cabundle_controller_test.go
+++ b/pkg/controller/configmapcainjector/controller/sa_token_cabundle_controller_test.go
@@ -1,0 +1,145 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/fake"
+	listers "k8s.io/client-go/listers/core/v1"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/service-serving-cert-signer/pkg/controller/api"
+)
+
+func TestSyncSATokenCABundle(t *testing.T) {
+	tests := []struct {
+		name            string
+		startingSecrets []runtime.Object
+		namespace       string
+		secretName      string
+		caBundle        string
+		validateActions func(t *testing.T, actions []clienttesting.Action)
+	}{
+		{
+			name:       "missing",
+			namespace:  "foo",
+			secretName: "foo",
+			caBundle:   "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "requested and empty",
+			startingSecrets: []runtime.Object{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "foo",
+					},
+					Data: map[string][]byte{},
+					Type: v1.SecretTypeServiceAccountToken,
+				},
+			},
+			namespace:  "foo",
+			secretName: "foo",
+			caBundle:   "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "secrets") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.Secret)
+				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "requested and different",
+			startingSecrets: []runtime.Object{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "foo",
+					},
+					Data: map[string][]byte{
+						api.InjectionDataKey: []byte("foo"),
+					},
+					Type: v1.SecretTypeServiceAccountToken,
+				},
+			},
+			namespace:  "foo",
+			secretName: "foo",
+			caBundle:   "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "secrets") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.Secret)
+				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "requested and same",
+			startingSecrets: []runtime.Object{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "foo",
+					},
+					Data: map[string][]byte{
+						api.InjectionDataKey: []byte("content"),
+					},
+					Type: v1.SecretTypeServiceAccountToken,
+				},
+			},
+			namespace:  "foo",
+			secretName: "foo",
+			caBundle:   "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tc.startingSecrets...)
+			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, secret := range tc.startingSecrets {
+				index.Add(secret)
+			}
+			c := &saTokenCABundleInjectionController{
+				secretsLister: listers.NewSecretLister(index),
+				secretsClient: fakeClient.CoreV1(),
+				ca:            []byte(tc.caBundle),
+			}
+
+			obj, err := c.Key(tc.namespace, tc.secretName)
+			if err == nil {
+				if err := c.Sync(obj); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			tc.validateActions(t, fakeClient.Actions())
+		})
+	}
+}

--- a/pkg/controller/configmapcainjector/starter/starter.go
+++ b/pkg/controller/configmapcainjector/starter/starter.go
@@ -56,9 +56,16 @@ func (o *configMapCABundleInjectorOptions) runConfigMapCABundleInjector(clientCo
 		o.ca,
 	)
 
+	saTokenCABundleInjectorController := controller.NewSATokenCABundleInjectionController(
+		kubeInformers.Core().V1().Secrets(),
+		kubeClient.CoreV1(),
+		o.ca,
+	)
+
 	kubeInformers.Start(stopCh)
 
 	go configMapInjectorController.Run(5, stopCh)
+	go saTokenCABundleInjectorController.Run(5, stopCh)
 
 	<-stopCh
 

--- a/pkg/operator/v310_00_assets/bindata.go
+++ b/pkg/operator/v310_00_assets/bindata.go
@@ -393,6 +393,17 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 `)
 
 func v3100ConfigmapCabundleControllerClusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Add a control loop to the ca bundle injector controller that updates SA token secrets with the CA bundle under the key "service-ca.crt". This keeps the legacy behavior to allow some time for consumers of /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt to migrate over to the injected configmap bundle.
@openshift/sig-auth 