### PR TITLE
Enhance generic controller logic

### DIFF
--- a/pkg/boilerplate/controller/controller.go
+++ b/pkg/boilerplate/controller/controller.go
@@ -6,30 +6,98 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
-func New(name string, sync cache.ProcessFunc, cacheSyncs ...cache.InformerSynced) (*Controller, workqueue.RateLimitingInterface) {
+type Runner interface {
+	Run(workers int, stopCh <-chan struct{})
+}
+
+func New(name string, sync Syncer) *Controller {
 	c := &Controller{
-		name:        name,
-		syncHandler: sync,
-		cacheSyncs:  cacheSyncs,
-		queue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
+		name: name,
+		sync: sync,
 	}
-	return c, c.queue
+	return c.WithRateLimiter(workqueue.DefaultControllerRateLimiter())
 }
 
 type Controller struct {
-	name        string
-	syncHandler cache.ProcessFunc
-	cacheSyncs  []cache.InformerSynced
-	queue       workqueue.RateLimitingInterface
+	name string
+	sync Syncer
+
+	queue      workqueue.RateLimitingInterface
+	maxRetries int
+
+	cacheSyncs []cache.InformerSynced
 }
 
-// Run starts the serviceCertSigner and blocks until stopCh is closed.
+func (c *Controller) WithMaxRetries(maxRetries int) *Controller {
+	c.maxRetries = maxRetries
+	return c
+}
+
+func (c *Controller) WithRateLimiter(limiter workqueue.RateLimiter) *Controller {
+	c.queue = workqueue.NewNamedRateLimitingQueue(limiter, c.name)
+	return c
+}
+
+func (c *Controller) WithInformerSynced(synced cache.InformerSynced) *Controller {
+	c.cacheSyncs = append(c.cacheSyncs, synced)
+	return c
+}
+
+func (c *Controller) WithInformer(informer cache.SharedInformer, filter Filter) *Controller {
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			object := metaOrDie(obj)
+			if filter.Add(object) {
+				glog.V(4).Infof("%s: handling add %s/%s", c.name, object.GetNamespace(), object.GetName())
+				c.add(filter, object)
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldObject := metaOrDie(oldObj)
+			newObject := metaOrDie(newObj)
+			if filter.Update(oldObject, newObject) {
+				glog.V(4).Infof("%s: handling update %s/%s", c.name, newObject.GetNamespace(), newObject.GetName())
+				c.add(filter, newObject)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			accessor, err := meta.Accessor(obj)
+			if err != nil {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					utilruntime.HandleError(fmt.Errorf("could not get object from tombstone: %+v", obj))
+					return
+				}
+				accessor, err = meta.Accessor(tombstone.Obj)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an accessor: %+v", obj))
+					return
+				}
+			}
+			if filter.Delete(accessor) {
+				glog.V(4).Infof("%s: handling delete %s/%s", c.name, accessor.GetNamespace(), accessor.GetName())
+				c.add(filter, accessor)
+			}
+		},
+	})
+	return c.WithInformerSynced(informer.GetController().HasSynced)
+}
+
+func (c *Controller) add(filter Filter, object v1.Object) {
+	parent := filter.Parent(object)
+	qKey := queueKey{namespace: object.GetNamespace(), name: parent}
+	c.queue.Add(qKey)
+}
+
 func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
@@ -59,16 +127,53 @@ func (c *Controller) processNextWorkItem() bool {
 	if quit {
 		return false
 	}
-	defer c.queue.Done(key)
 
-	err := c.syncHandler(key)
-	if err == nil {
-		c.queue.Forget(key)
-		return true
-	}
+	qKey := key.(queueKey)
+	defer c.queue.Done(qKey)
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", key, err))
-	c.queue.AddRateLimited(key)
+	err := c.handleSync(qKey)
+	c.handleKey(qKey, err)
 
 	return true
+}
+
+func (c *Controller) handleSync(key queueKey) error {
+	obj, err := c.sync.Key(key.namespace, key.name)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return c.sync.Sync(obj)
+}
+
+func (c *Controller) handleKey(key queueKey, err error) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	retryForever := c.maxRetries <= 0
+	if retryForever || c.queue.NumRequeues(key) < c.maxRetries {
+		utilruntime.HandleError(fmt.Errorf("%v failed with: %v", key, err))
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	utilruntime.HandleError(fmt.Errorf("dropping key %v out of the queue: %v", key, err))
+	c.queue.Forget(key)
+}
+
+type queueKey struct {
+	namespace string
+	name      string
+}
+
+func metaOrDie(obj interface{}) v1.Object {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		panic(err) // this should never happen
+	}
+	return accessor
 }

--- a/pkg/boilerplate/controller/filter.go
+++ b/pkg/boilerplate/controller/filter.go
@@ -1,0 +1,45 @@
+package controller
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type Filter interface {
+	Parent(obj v1.Object) (name string)
+	Add(obj v1.Object) bool
+	Update(oldObj, newObj v1.Object) bool
+	Delete(obj v1.Object) bool
+}
+
+type FilterFuncs struct {
+	ParentFunc func(obj v1.Object) (name string)
+	AddFunc    func(obj v1.Object) bool
+	UpdateFunc func(oldObj, newObj v1.Object) bool
+	DeleteFunc func(obj v1.Object) bool
+}
+
+func (f FilterFuncs) Parent(obj v1.Object) string {
+	if f.ParentFunc == nil {
+		return obj.GetName()
+	}
+	return f.ParentFunc(obj)
+}
+
+func (f FilterFuncs) Add(obj v1.Object) bool {
+	if f.AddFunc == nil {
+		return false
+	}
+	return f.AddFunc(obj)
+}
+
+func (f FilterFuncs) Update(oldObj, newObj v1.Object) bool {
+	if f.UpdateFunc == nil {
+		return false
+	}
+	return f.UpdateFunc(oldObj, newObj)
+}
+
+func (f FilterFuncs) Delete(obj v1.Object) bool {
+	if f.DeleteFunc == nil {
+		return false
+	}
+	return f.DeleteFunc(obj)
+}

--- a/pkg/boilerplate/controller/sync.go
+++ b/pkg/boilerplate/controller/sync.go
@@ -1,0 +1,10 @@
+package controller
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type Syncer interface {
+	Key(namespace, name string) (v1.Object, error)
+	Sync(v1.Object) error
+}
+
+type SyncFunc func(v1.Object) error

--- a/pkg/controller/api/api.go
+++ b/pkg/controller/api/api.go
@@ -1,16 +1,25 @@
 package api
 
-import "strings"
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	InjectCABundleAnnotationName = "service.alpha.openshift.io/inject-cabundle"
 	InjectionDataKey             = "service-ca.crt"
 )
 
-func HasInjectCABundleAnnotation(annotations map[string]string) bool {
-	return strings.EqualFold(annotations[InjectCABundleAnnotationName], "true")
+func HasInjectCABundleAnnotation(metadata v1.Object) bool {
+	return strings.EqualFold(metadata.GetAnnotations()[InjectCABundleAnnotationName], "true")
 }
 
+func HasInjectCABundleAnnotationUpdate(old, cur v1.Object) bool {
+	return HasInjectCABundleAnnotation(cur)
+}
+
+// Annotations on service
 const (
 	// ServingCertSecretAnnotation stores the name of the secret to generate into.
 	ServingCertSecretAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"
@@ -23,6 +32,10 @@ const (
 	// ServingCertErrorNumAnnotation stores how many consecutive errors we've hit.  A value of the maxRetries will prevent
 	// the controller from reattempting until it is cleared.
 	ServingCertErrorNumAnnotation = "service.alpha.openshift.io/serving-cert-generation-error-num"
+)
+
+// Annotations on secret
+const (
 	// ServiceUIDAnnotation is an annotation on a secret that indicates which service created it, by UID
 	ServiceUIDAnnotation = "service.alpha.openshift.io/originating-service-uid"
 	// ServiceNameAnnotation is an annotation on a secret that indicates which service created it, by Name to allow reverse lookups on services

--- a/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller.go
+++ b/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller.go
@@ -2,15 +2,9 @@ package controller
 
 import (
 	"bytes"
-	"fmt"
 
-	"github.com/golang/glog"
-
-	kapierrors "k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	apiregistrationapiv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiserviceclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
 	apiserviceinformer "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1"
 	apiservicelister "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1"
@@ -19,56 +13,36 @@ import (
 	"github.com/openshift/service-serving-cert-signer/pkg/controller/api"
 )
 
-type ServiceServingCertUpdateController struct {
+type serviceServingCertUpdateController struct {
 	apiServiceClient apiserviceclient.APIServicesGetter
 	apiServiceLister apiservicelister.APIServiceLister
 
 	caBundle []byte
-
-	// services that need to be checked
-	queue workqueue.RateLimitingInterface
-
-	// standard controller loop
-	*controller.Controller
 }
 
-func NewAPIServiceCABundleInjector(apiServiceInformer apiserviceinformer.APIServiceInformer, apiServiceClient apiserviceclient.APIServicesGetter, caBundle []byte) *ServiceServingCertUpdateController {
-	sc := &ServiceServingCertUpdateController{
+func NewAPIServiceCABundleInjector(apiServiceInformer apiserviceinformer.APIServiceInformer, apiServiceClient apiserviceclient.APIServicesGetter, caBundle []byte) controller.Runner {
+	sc := &serviceServingCertUpdateController{
 		apiServiceClient: apiServiceClient,
 		apiServiceLister: apiServiceInformer.Lister(),
 		caBundle:         caBundle,
 	}
 
-	apiServiceInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    sc.addAPIService,
-			UpdateFunc: sc.updateAPIService,
-		},
-	)
-
-	internalController, queue := controller.New("APIServiceCABundleInjector", sc.syncAPIService, apiServiceInformer.Informer().GetController().HasSynced)
-
-	sc.Controller = internalController
-	sc.queue = queue
-
-	return sc
+	return controller.New("APIServiceCABundleInjector", sc).
+		WithInformer(apiServiceInformer.Informer(), controller.FilterFuncs{
+			AddFunc:    api.HasInjectCABundleAnnotation,
+			UpdateFunc: api.HasInjectCABundleAnnotationUpdate,
+		})
 }
 
-func (c *ServiceServingCertUpdateController) syncAPIService(obj interface{}) error {
-	key := obj.(string)
-	_, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
-	}
+func (c *serviceServingCertUpdateController) Key(namespace, name string) (v1.Object, error) {
+	return c.apiServiceLister.Get(name)
+}
 
-	apiService, err := c.apiServiceLister.Get(name)
-	if kapierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if !api.HasInjectCABundleAnnotation(apiService.Annotations) {
+func (c *serviceServingCertUpdateController) Sync(obj v1.Object) error {
+	apiService := obj.(*apiregistrationv1.APIService)
+
+	// check if we need to do anything
+	if !api.HasInjectCABundleAnnotation(apiService) {
 		return nil
 	}
 	if bytes.Equal(apiService.Spec.CABundle, c.caBundle) {
@@ -76,32 +50,8 @@ func (c *ServiceServingCertUpdateController) syncAPIService(obj interface{}) err
 	}
 
 	// avoid mutating our cache
-	apiServiceToUpdate := apiService.DeepCopy()
-	apiServiceToUpdate.Spec.CABundle = c.caBundle
-	_, err = c.apiServiceClient.APIServices().Update(apiServiceToUpdate)
+	apiServiceCopy := apiService.DeepCopy()
+	apiServiceCopy.Spec.CABundle = c.caBundle
+	_, err := c.apiServiceClient.APIServices().Update(apiServiceCopy)
 	return err
-}
-
-func (c *ServiceServingCertUpdateController) handleAPIService(obj interface{}, event string) {
-	apiService := obj.(*apiregistrationapiv1.APIService)
-	if !api.HasInjectCABundleAnnotation(apiService.Annotations) {
-		return
-	}
-
-	glog.V(4).Infof("%s %s", event, apiService.Name)
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("could not get key for object %+v: %v", obj, err))
-		return
-	}
-
-	c.queue.Add(key)
-}
-
-func (c *ServiceServingCertUpdateController) addAPIService(obj interface{}) {
-	c.handleAPIService(obj, "adding")
-}
-
-func (c *ServiceServingCertUpdateController) updateAPIService(old, cur interface{}) {
-	c.handleAPIService(cur, "updating")
 }

--- a/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
+++ b/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
@@ -109,16 +109,19 @@ func TestSyncAPIService(t *testing.T) {
 				index.Add(apiService)
 			}
 
-			c := &ServiceServingCertUpdateController{
+			c := &serviceServingCertUpdateController{
 				apiServiceLister: apiservicelister.NewAPIServiceLister(index),
 				apiServiceClient: fakeClient.ApiregistrationV1(),
 				caBundle:         tc.caBundle,
 			}
 
-			err := c.syncAPIService(tc.key)
-			if err != nil {
-				t.Fatal(err)
+			obj, err := c.Key("", tc.key)
+			if err == nil {
+				if err := c.Sync(obj); err != nil {
+					t.Fatal(err)
+				}
 			}
+
 			tc.validateActions(t, fakeClient.Actions())
 		})
 	}

--- a/pkg/controller/configmapcainjector/controller/configmap_injecting_controller.go
+++ b/pkg/controller/configmapcainjector/controller/configmap_injecting_controller.go
@@ -1,19 +1,11 @@
 package controller
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/golang/glog"
-
-	"k8s.io/api/core/v1"
-	kapierrors "k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	informers "k8s.io/client-go/informers/core/v1"
 	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/openshift/service-serving-cert-signer/pkg/boilerplate/controller"
 	"github.com/openshift/service-serving-cert-signer/pkg/controller/api"
@@ -21,57 +13,38 @@ import (
 
 // ConfigMapCABundleInjectionController is responsible for injecting a CA bundle into configMaps annotated with
 // "service.alpha.openshift.io/inject-cabundle"
-type ConfigMapCABundleInjectionController struct {
+type configMapCABundleInjectionController struct {
 	configMapClient kcoreclient.ConfigMapsGetter
 	configMapLister listers.ConfigMapLister
 
 	ca string
-
-	// configMaps that need to be checked
-	queue workqueue.RateLimitingInterface
-
-	// standard controller loop
-	*controller.Controller
 }
 
-func NewConfigMapCABundleInjectionController(configMaps informers.ConfigMapInformer, configMapsClient kcoreclient.ConfigMapsGetter, ca string, resyncInterval time.Duration) *ConfigMapCABundleInjectionController {
-	ic := &ConfigMapCABundleInjectionController{
+func NewConfigMapCABundleInjectionController(configMaps informers.ConfigMapInformer, configMapsClient kcoreclient.ConfigMapsGetter, ca string) controller.Runner {
+	ic := &configMapCABundleInjectionController{
 		configMapClient: configMapsClient,
 		configMapLister: configMaps.Lister(),
 		ca:              ca,
 	}
 
-	configMaps.Informer().AddEventHandlerWithResyncPeriod(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    ic.addConfigMap,
-			UpdateFunc: ic.updateConfigMap,
-		},
-		resyncInterval,
-	)
-
-	internalController, queue := controller.New("ConfigMapCABundleInjectionController", ic.syncConfigMap, configMaps.Informer().HasSynced)
-
-	ic.Controller = internalController
-	ic.queue = queue
-
-	return ic
+	return controller.New("ConfigMapCABundleInjectionController", ic).
+		WithInformer(configMaps.Informer(), controller.FilterFuncs{
+			AddFunc:    api.HasInjectCABundleAnnotation,
+			UpdateFunc: api.HasInjectCABundleAnnotationUpdate,
+		})
 }
 
-func (ic *ConfigMapCABundleInjectionController) syncConfigMap(obj interface{}) error {
-	key := obj.(string)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
-	}
+func (ic *configMapCABundleInjectionController) Key(namespace, name string) (v1.Object, error) {
+	return ic.configMapLister.ConfigMaps(namespace).Get(name)
+}
 
-	sharedConfigMap, err := ic.configMapLister.ConfigMaps(namespace).Get(name)
-	if kapierrors.IsNotFound(err) {
+func (ic *configMapCABundleInjectionController) Sync(obj v1.Object) error {
+	sharedConfigMap := obj.(*corev1.ConfigMap)
+
+	// check if we need to do anything
+	if !api.HasInjectCABundleAnnotation(sharedConfigMap) {
 		return nil
 	}
-	if err != nil {
-		return err
-	}
-
 	// skip updating when the CA bundle is already there
 	if data, ok := sharedConfigMap.Data[api.InjectionDataKey]; ok && data == ic.ca {
 		return nil
@@ -86,30 +59,6 @@ func (ic *ConfigMapCABundleInjectionController) syncConfigMap(obj interface{}) e
 
 	configMapCopy.Data[api.InjectionDataKey] = ic.ca
 
-	_, err = ic.configMapClient.ConfigMaps(configMapCopy.Namespace).Update(configMapCopy)
+	_, err := ic.configMapClient.ConfigMaps(configMapCopy.Namespace).Update(configMapCopy)
 	return err
-}
-
-func (c *ConfigMapCABundleInjectionController) handleConfigMap(obj interface{}, event string) {
-	cm := obj.(*v1.ConfigMap)
-	if !api.HasInjectCABundleAnnotation(cm.Annotations) {
-		return
-	}
-
-	glog.V(4).Infof("%s %s", event, cm.Name)
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("could not get key for object %+v: %v", obj, err))
-		return
-	}
-
-	c.queue.Add(key)
-}
-
-func (c *ConfigMapCABundleInjectionController) addConfigMap(obj interface{}) {
-	c.handleConfigMap(obj, "adding")
-}
-
-func (c *ConfigMapCABundleInjectionController) updateConfigMap(old, cur interface{}) {
-	c.handleConfigMap(cur, "updating")
 }

--- a/pkg/controller/configmapcainjector/starter/starter.go
+++ b/pkg/controller/configmapcainjector/starter/starter.go
@@ -43,29 +43,22 @@ type configMapCABundleInjectorOptions struct {
 	ca string
 }
 
-// These might need adjustment
-const (
-	InformerResyncInterval   = 2 * time.Minute
-	ControllerResyncInterval = 20 * time.Minute
-)
-
 func (o *configMapCABundleInjectorOptions) runConfigMapCABundleInjector(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	kubeClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
 		return err
 	}
-	kubeInformers := informers.NewSharedInformerFactory(kubeClient, InformerResyncInterval)
+	kubeInformers := informers.NewSharedInformerFactory(kubeClient, 20*time.Minute)
 
 	configMapInjectorController := controller.NewConfigMapCABundleInjectionController(
 		kubeInformers.Core().V1().ConfigMaps(),
 		kubeClient.CoreV1(),
 		o.ca,
-		ControllerResyncInterval,
 	)
 
 	kubeInformers.Start(stopCh)
 
-	go configMapInjectorController.Run(1, stopCh)
+	go configMapInjectorController.Run(5, stopCh)
 
 	<-stopCh
 

--- a/pkg/controller/servingcert/controller/secret_updating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller.go
@@ -4,16 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
-
 	"k8s.io/api/core/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	informers "k8s.io/client-go/informers/core/v1"
 	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	ocontroller "github.com/openshift/library-go/pkg/controller"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -21,7 +18,7 @@ import (
 	"github.com/openshift/service-serving-cert-signer/pkg/controller/api"
 )
 
-type ServiceServingCertUpdateController struct {
+type serviceServingCertUpdateController struct {
 	secretClient kcoreclient.SecretsGetter
 
 	serviceLister listers.ServiceLister
@@ -31,16 +28,10 @@ type ServiceServingCertUpdateController struct {
 	dnsSuffix string
 	// minTimeLeftForCert is how much time is remaining for the serving cert before regenerating it.
 	minTimeLeftForCert time.Duration
-
-	// secrets that need to be checked
-	queue workqueue.RateLimitingInterface
-
-	// standard controller loop
-	*controller.Controller
 }
 
-func NewServiceServingCertUpdateController(services informers.ServiceInformer, secrets informers.SecretInformer, secretClient kcoreclient.SecretsGetter, ca *crypto.CA, dnsSuffix string, resyncInterval time.Duration) *ServiceServingCertUpdateController {
-	sc := &ServiceServingCertUpdateController{
+func NewServiceServingCertUpdateController(services informers.ServiceInformer, secrets informers.SecretInformer, secretClient kcoreclient.SecretsGetter, ca *crypto.CA, dnsSuffix string) controller.Runner {
+	sc := &serviceServingCertUpdateController{
 		secretClient:  secretClient,
 		serviceLister: services.Lister(),
 		secretLister:  secrets.Lister(),
@@ -51,71 +42,32 @@ func NewServiceServingCertUpdateController(services informers.ServiceInformer, s
 		minTimeLeftForCert: 1 * time.Hour,
 	}
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
-		cache.ResourceEventHandlerFuncs{
+	return controller.New("ServiceServingCertUpdateController", sc).
+		WithInformerSynced(services.Informer().GetController().HasSynced).
+		WithInformer(secrets.Informer(), controller.FilterFuncs{
 			AddFunc:    sc.addSecret,
 			UpdateFunc: sc.updateSecret,
-		},
-		resyncInterval,
-	)
-
-	internalController, queue := controller.New("ServiceServingCertUpdateController", sc.syncSecret,
-		services.Informer().GetController().HasSynced, secrets.Informer().GetController().HasSynced)
-
-	sc.Controller = internalController
-	sc.queue = queue
-
-	return sc
+		})
 }
 
-func (sc *ServiceServingCertUpdateController) enqueueSecret(obj *v1.Secret) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err != nil {
-		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
-		return
-	}
-
-	sc.queue.Add(key)
-}
-
-func (sc *ServiceServingCertUpdateController) addSecret(obj interface{}) {
+func (sc *serviceServingCertUpdateController) addSecret(obj metav1.Object) bool {
 	secret := obj.(*v1.Secret)
-	if _, ok := toServiceName(secret); !ok {
-		return
-	}
-
-	glog.V(4).Infof("adding %s", secret.Name)
-	sc.enqueueSecret(secret)
+	_, ok := toServiceName(secret)
+	return ok
 }
 
-func (sc *ServiceServingCertUpdateController) updateSecret(old, cur interface{}) {
-	secret := cur.(*v1.Secret)
-	if _, ok := toServiceName(secret); !ok {
-		// if the current doesn't have a service name, check the old
-		secret = old.(*v1.Secret)
-		if _, ok := toServiceName(secret); !ok {
-			return
-		}
-	}
-
-	glog.V(4).Infof("updating %s", secret.Name)
-	sc.enqueueSecret(secret)
+func (sc *serviceServingCertUpdateController) updateSecret(old, cur metav1.Object) bool {
+	// if the current doesn't have a service name, check the old
+	// TODO drop this
+	return sc.addSecret(cur) || sc.addSecret(old)
 }
 
-func (sc *ServiceServingCertUpdateController) syncSecret(obj interface{}) error {
-	key := obj.(string)
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
-	}
+func (sc *serviceServingCertUpdateController) Key(namespace, name string) (metav1.Object, error) {
+	return sc.secretLister.Secrets(namespace).Get(name)
+}
 
-	sharedSecret, err := sc.secretLister.Secrets(namespace).Get(name)
-	if kapierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
+func (sc *serviceServingCertUpdateController) Sync(obj metav1.Object) error {
+	sharedSecret := obj.(*v1.Secret)
 
 	regenerate, service := sc.requiresRegeneration(sharedSecret)
 	if !regenerate {
@@ -129,11 +81,11 @@ func (sc *ServiceServingCertUpdateController) syncSecret(obj interface{}) error 
 		return err
 	}
 
-	_, err = sc.secretClient.Secrets(secretCopy.Namespace).Update(secretCopy)
+	_, err := sc.secretClient.Secrets(secretCopy.Namespace).Update(secretCopy)
 	return err
 }
 
-func (sc *ServiceServingCertUpdateController) requiresRegeneration(secret *v1.Secret) (bool, *v1.Service) {
+func (sc *serviceServingCertUpdateController) requiresRegeneration(secret *v1.Secret) (bool, *v1.Service) {
 	serviceName, ok := toServiceName(secret)
 	if !ok {
 		return false, nil

--- a/pkg/controller/servingcert/controller/secret_updating_controller_test.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller_test.go
@@ -185,7 +185,7 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-			c := &ServiceServingCertUpdateController{
+			c := &serviceServingCertUpdateController{
 				serviceLister: listers.NewServiceLister(index),
 			}
 			tc.primeServices(index)

--- a/pkg/controller/servingcert/starter/starter.go
+++ b/pkg/controller/servingcert/starter/starter.go
@@ -33,7 +33,7 @@ func (o *servingCertOptions) runServingCert(clientConfig *rest.Config, stopCh <-
 	if err != nil {
 		return err
 	}
-	kubeInformers := informers.NewSharedInformerFactory(kubeClient, 2*time.Minute)
+	kubeInformers := informers.NewSharedInformerFactory(kubeClient, 20*time.Minute)
 
 	servingCertController := controller.NewServiceServingCertController(
 		kubeInformers.Core().V1().Services(),
@@ -43,7 +43,6 @@ func (o *servingCertOptions) runServingCert(clientConfig *rest.Config, stopCh <-
 		o.ca,
 		// TODO this needs to be configurable
 		"cluster.local",
-		2*time.Minute,
 	)
 	servingCertUpdateController := controller.NewServiceServingCertUpdateController(
 		kubeInformers.Core().V1().Services(),
@@ -52,12 +51,11 @@ func (o *servingCertOptions) runServingCert(clientConfig *rest.Config, stopCh <-
 		o.ca,
 		// TODO this needs to be configurable
 		"cluster.local",
-		20*time.Minute,
 	)
 
 	kubeInformers.Start(stopCh)
 
-	go servingCertController.Run(1, stopCh)
+	go servingCertController.Run(5, stopCh)
 	go servingCertUpdateController.Run(5, stopCh)
 
 	<-stopCh


### PR DESCRIPTION
This further reduces boilerplate in the controller sync loops.  Enhancements need to be made to handle the singleton operator flow.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 