### PR TITLE
Make the signing CA last 1 year

### DIFF
--- a/pkg/operator/sync_signer_v311_00.go
+++ b/pkg/operator/sync_signer_v311_00.go
@@ -111,7 +111,7 @@ func manageSigningSecret_v311_00_to_latest(client coreclientv1.SecretsGetter) (*
 		return existing, false, err
 	}
 
-	ca, err := crypto.MakeCAConfig(serviceServingCertSignerName(), 10)
+	ca, err := crypto.MakeCAConfig(serviceServingCertSignerName(), 365)
 	if err != nil {
 		return existing, false, err
 	}


### PR DESCRIPTION
Prolong the life of the service signing CA from 10 days to 730.